### PR TITLE
Error Logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ TypeAuthD supports native SSL certificates out-of-the-box or can operate behind 
 ```
 Make sure to fill in all the necessary fields in `appconfig.json` for proper configuration.
 
+## Logging
+This application supports file handlers(only when `NODE_ENV=production`), you can find `lnav-fmt.json` format for `lnav` to read typeauthd logs in pretty formatting.   
+Whenever server results in 500 error, it throws `client logs` to the user, so he can download them and report this situation, you, as a host, can find the situation in logs by looking over them by `id` field. This one helps in searching the context error happened in.
+
 ## Routes Overview
 
 This app exposes some intresting routes you should know.

--- a/src/types/web.d.ts
+++ b/src/types/web.d.ts
@@ -93,7 +93,7 @@ export interface LinkQueryParams {
 }
 
 export interface DataParams {
-    c: string
+    b64: string
 }
 
 /// Express Helper Structs

--- a/src/web/controllers/auth.ts
+++ b/src/web/controllers/auth.ts
@@ -24,6 +24,7 @@ export class AuthController {
     }
 
     public static async getLogin(req: LocaleExtendedRequest, res: Response) {
+        const locale = req.locale!;
         let uid = req.query['uid']?.toString() ?? undefined;
 
         const locale = req.locale!;
@@ -60,15 +61,24 @@ export class AuthController {
             const data = {
                 ip: req.ip,
                 http_ver: req.httpVersion,
+                protocol: req.protocol,
                 url: req.url,
+
+                err: "Unable to fetch identify scope",
+            }
+            const jsonData = JSON.stringify(data);
+            const dataId = {
+                id: btoa(jsonData),
+                data
             }
 
             // TODO: Add errLogs with above
-            WebHelpers.respondErr(
+            WebHelpers.respondErrWithLogs(
                 res, 
                 'Unable to fetch identify scope', 
                 500, 
-                'You cannot do anything with this, address the issue to developer', 
+                'You cannot do anything with this, address the issue to developer',
+                btoa(JSON.stringify(dataId)),
                 locale
             );
             return;

--- a/src/web/controllers/root.ts
+++ b/src/web/controllers/root.ts
@@ -5,10 +5,23 @@ export class RootController {
     public static collectToRouter() {
         const router = Router();
         router.get('/', this.getRoot);
+        router.get('/logs', this.getLogs);
         return router;
     }
 
     public static async getRoot(req: Request, res: Response) {
         res.redirect('/auth/login');
+    }
+
+    public static async getLogs(req: Request, res: Response) {
+        const data = WebHelpers.validateDataParams(req.query);
+
+        if (!data) {
+            res.status(400).json({error: "Expected data to be provided!"});
+            return;
+        }
+
+        res.set({"Content-Disposition":"attachment; filename=\"typeauthd-logs.log\""});
+        res.send(atob(data.b64));
     }
 }

--- a/src/web/helpers.ts
+++ b/src/web/helpers.ts
@@ -30,6 +30,13 @@ export class WebHelpers {
         res.status(code).render('error', {title: 'Error', statusCode: code, errorTitle: msg, errorDescription: help, errorText})
     }
 
+    public static respondErrWithLogs(res: ExResponse, msg: string, code: number, help: string, data: string, locale: string | undefined = undefined) {
+        const errorText = locales.loc("error_title", locale ?? config.locale);
+        res.status(code).render('error', {title: "Error", statusCode: code, errorTitle: msg, errorDescription: help, errorText, logsLink: `/logs?b64=${btoa(data)}`})
+        
+        Logger.get().error("500 - Server Error", {err: data});
+    }
+
     /// Discord Related Helpers
 
     public static parseCodeQuery(req: ExRequest): DiscordCodeQuery | null {
@@ -256,12 +263,12 @@ export class WebHelpers {
             return null;
         }
 
-        const {c}= query;
-        if (typeof c !== 'string' || c.trim() === '') {
+        const {b64}= query;
+        if (typeof b64 !== 'string' || b64.trim() === '') {
             return null;
         }
 
-        return { c } as DataParams; 
+        return { b64 } as DataParams; 
     }
 
     public static async fetchRecordByMethod(db: IDatabase, id: string, method: SearchMethod): Promise<AuthorizedRecord | undefined> {


### PR DESCRIPTION
Provide error logs on internal server error, so user can download them and send to host or developer for investigation. This shit helps in finding the context of the error(i tired of this in ssj_auth with its shitty logs)